### PR TITLE
Set default oscillator pitch to C4

### DIFF
--- a/src/mom-jeans.cpp
+++ b/src/mom-jeans.cpp
@@ -112,7 +112,7 @@ struct MomJeansBase : Module {
 
 	MomJeansBase() {
 		config(PARAMS_LEN, INPUTS_LEN, OUTPUTS_LEN, LIGHTS_LEN);
-		configParam(PITCH_PARAM, 0.f, 1.f, 0.25f, "Pitch");
+		configParam(PITCH_PARAM, 0.f, 1.f, 16.f/26.f, "Pitch"); // default to C4
 		frequencyParamQuantity = new FrequencyParamQuantity();
 		paramQuantities[PITCH_PARAM] = frequencyParamQuantity;
 		paramQuantities[PITCH_PARAM]->name = "Pitch";


### PR DESCRIPTION
## Summary
- Changed the default pitch parameter for Mom Jeans from 0.25 to 16/26 (~0.615), which corresponds to C4

## Context
Per the [VCV Rack Voltage Standards](https://vcvrack.com/manual/VoltageStandards):

> At its default position, audio-rate oscillators should use a baseline of the note C4 defined by International Pitch Notation ("middle C", MIDI note 60, f0 = 261.6256 Hz = `dsp::FREQ_C4`).