### PR TITLE
Fix sync input: edge detection instead of level detection

### DIFF
--- a/src/mom-jeans.cpp
+++ b/src/mom-jeans.cpp
@@ -64,6 +64,11 @@ struct FrequencyParamQuantity : ParamQuantity {
 struct MomJeansBase : Module {
 	FrequencyParamQuantity *frequencyParamQuantity;
 
+	// Per-channel edge detector for the sync input. The sync argument to
+	// pulsar_process() resets the phasor, so it must fire only on the rising
+	// edge — passing a raw level retriggers every sample while sync is high.
+	dsp::SchmittTrigger sync_triggers[16];
+
 	enum Theme {
 		FOLLOW = 0,  // Add this = 0,
 		LIGHT = 1,
@@ -334,7 +339,7 @@ struct MomJeansBase : Module {
 				waveform,
 				quantization > 0.5f ? 1 : 0,
 				coupling > 0.5f ? 1 : 0,
-				sync > 2.5f ? 1 : 0,
+				sync_triggers[c].process(sync, 0.1f, 2.f) ? 1 : 0,
 				c
 			);
 


### PR DESCRIPTION
## Problem

The sync input used level detection — `sync > 2.5f ? 1 : 0` — which passes a reset to `pulsar_process()` on *every* sample while the sync signal is above 2.5 V. Since the reset retriggers the phasor each sample, holding sync high
(any sustained gate or audio-rate sync source) continuously resets the oscillator and produces loud noise instead of hard sync.

## Fix

Detect the rising edge with a per-channel `dsp::SchmittTrigger` so the phasor resets once per sync transition, as intended. Thresholds (0.1 V / 2 V) bracket the original 2.5 V trip point with hysteresis.

Two-line change plus a 16-channel trigger array on `MomJeansBase`; builds cleanly against Rack SDK 2.6.4.